### PR TITLE
Don't include a hyperlink if href attribute is nil

### DIFF
--- a/lib/roar/representer/feature/hypermedia.rb
+++ b/lib/roar/representer/feature/hypermedia.rb
@@ -37,11 +37,13 @@ module Roar
           links_def       = find_links_definition or return
           hyperlink_class = links_def.sought_type
           
-          links_def.rel2block.each do |link|
-            links.update_link(hyperlink_class.new.tap do |hyperlink|  # create Hyperlink representer.
+          links_def.rel2block.each do |link|          
+            hyperlink_representer = hyperlink_class.new.tap do |hyperlink|  # create Hyperlink representer.
               hyperlink.rel   = link[:rel]
               hyperlink.href  = run_link_block(link[:block])
-            end)
+            end
+            # Only include link if href not nil
+            links.update_link(hyperlink_representer) if hyperlink_representer.href
           end
         end
         


### PR DESCRIPTION
Hi!

In the context of https://github.com/apotonick/representable/pull/2 I noticed a small inconsistency. Properties with nil values don't get included but links with a nil href attribute stay in the representation.
A future `:include_nil` option could affect this behavior, too.

Note: This pull request only illustrates the problem and shouldn't be merged as it is.
