### PR TITLE
Correctly implemented JSON HAL format

### DIFF
--- a/lib/roar/representer/json/hal.rb
+++ b/lib/roar/representer/json/hal.rb
@@ -28,7 +28,7 @@ module Roar::Representer
       #
       # Renders to
       #
-      #   {"links":{"self":"http://self"}}
+      #   {"links":{"self":{"href":"http://self"}}}
       #
       # Note that the HAL::Links module alone doesn't prepend an underscore to +links+. Use the JSON::HAL module for that.
       module Links
@@ -45,14 +45,14 @@ module Roar::Representer
           def to_hash(*)
             {}.tap do |hash|
               each do |link|
-                hash[link.rel] = link.href
+                hash[link.rel] = {"href" => link.href}
               end
             end
           end
           
           def from_hash(json, *)
             json.each do |k, v|
-              self << Feature::Hypermedia::Hyperlink.new(:rel => k, :href => v)
+              self << Feature::Hypermedia::Hyperlink.new(:rel => k, :href => v['href'])
             end
             self
           end

--- a/test/hal_json_test.rb
+++ b/test/hal_json_test.rb
@@ -23,11 +23,11 @@ class HalJsonTest < MiniTest::Spec
     end
     
     it "renders links plain with the links key" do
-      assert_equal "{\"links\":{\"self\":\"http://self\",\"next\":\"http://hit\"}}", @song.to_json
+      assert_equal "{\"links\":{\"self\":{\"href\":\"http://self\"},\"next\":{\"href\":\"http://hit\"}}}", @song.to_json
     end
     
     it "parses incoming JSON links correctly" do
-      @song.from_json "{\"links\":{\"self\":\"http://self\"}}"
+      @song.from_json "{\"links\":{\"self\":{\"href\":\"http://self\"}}}"
       assert_equal "http://self", @song.links[:self]
       assert_equal nil, @song.links[:next]
     end
@@ -50,7 +50,7 @@ class HalJsonTest < MiniTest::Spec
     end
     
     it "render links" do
-      assert_equal "{\"id\":1,\"items\":[],\"_links\":{\"self\":\"http://orders/1\"}}", Order.new(:id => 1).extend(OrderRepresenter).to_json
+      assert_equal "{\"id\":1,\"items\":[],\"_links\":{\"self\":{\"href\":\"http://orders/1\"}}}", Order.new(:id => 1).extend(OrderRepresenter).to_json
     end
   end
 end


### PR DESCRIPTION
HAL in JSON uses the object to [represent links with `href` key so that you can add other optional keys](git@github.com:miyagawa/roar.git). Fixed the JSON::HAL module to correctly implement that.

Also updated json_hal_test.rb to pass test on my rake environment. Sorry if this is due to some configuration issues on my end.
