### PR TITLE
Travis CI Fix: FakeServer should not raise errors

### DIFF
--- a/test/fake_server.rb
+++ b/test/fake_server.rb
@@ -2,6 +2,9 @@ require "bundler/setup"
 require 'sinatra/base'
 
 class FakeServer < Sinatra::Base
+
+  set :raise_errors, false
+
   get "/method" do
     "<method>get</method>"
   end


### PR DESCRIPTION
- Travis CI sets RACK_ENV to test, which will raise errors when using
  Sinatra's default settings.
  We want to test against FakeServer as if it is a production system.

Signed-off-by: Alex Coles alex@alexbcoles.com
