### PR TITLE
Allow data attributes for link elements

### DIFF
--- a/lib/roar/representer/feature/hypermedia.rb
+++ b/lib/roar/representer/feature/hypermedia.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Roar
   module Representer
     module Feature
@@ -122,18 +124,19 @@ module Roar
         
         # An abstract hypermedia link with +rel+, +href+ and other attributes.
         # Overwrite the Hyperlink.params method if you need more link attributes.
-        class Hyperlink
+        class Hyperlink < OpenStruct
           def self.params
             [:rel, :href, :media, :title, :hreflang]
           end
-          
-          attr_accessor *params
-          
+
+          # Default link attributes. These are required for parsing links from
+          # XML documents.
+          def self.defaults
+            self.params.each_with_object({}) { |p, defaults| defaults[p] = nil }
+          end
+
           def initialize(options={})
-            options.each do |k,v|
-              next unless self.class.params.include?(k.to_sym)
-              instance_variable_set("@#{k}", v)
-            end
+            super self.class.defaults.merge options
           end
         end
       end

--- a/lib/roar/representer/json.rb
+++ b/lib/roar/representer/json.rb
@@ -53,8 +53,16 @@ module Roar
       # Represents a hyperlink in standard roar+json. 
       module HyperlinkRepresenter
         include JSON
-        Feature::Hypermedia::Hyperlink.params.each do |attr|
-          property attr
+
+        class << self
+          alias_method :representable_extended, :extended
+          def extended( base )
+            representable_extended base
+
+            base.marshal_dump.keys.each do |attributes|
+              property attributes
+            end
+          end
         end
       end
     end

--- a/lib/roar/representer/xml.rb
+++ b/lib/roar/representer/xml.rb
@@ -52,8 +52,15 @@ module Roar
         
         self.representation_wrap = :link
         
-        Feature::Hypermedia::Hyperlink.params.each do |attr|
-          property attr, :attribute => true
+        class << self
+          alias_method :representable_extended, :extended
+          def extended( base )
+            representable_extended base
+
+            base.marshal_dump.keys.each do |attributes|
+              property attributes, :attribute => true
+            end
+          end
         end
       end
     end

--- a/test/hypermedia_feature_test.rb
+++ b/test/hypermedia_feature_test.rb
@@ -24,12 +24,12 @@ class HypermediaTest
 
       it "accepts any options" do
         @mod.class_eval do
-          link :rel => :self, :title => "Hey, @myabc" do
+          link :rel => :self, :title => "Hey, @myabc", 'data-foo' => 'bar' do
             "http://self"
           end
         end
 
-        assert_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"http://self\",\"title\":\"Hey, @myabc\"}]}", Object.new.extend(@mod).to_json
+        assert_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"http://self\",\"title\":\"Hey, @myabc\",\"data-foo\":\"bar\"}]}", Object.new.extend(@mod).to_json
       end
     end
 


### PR DESCRIPTION
This allows standard attributes such as `type` or custom data attributes such as `data-foo` without having to override `Hyperlink#params`.

I found overriding `Hyperlink#params`, as the documentation instructed, to be difficult to do at best, and impossible to do for data attributes because of the reliance on instance variables.

The crux of this Pull Request is that `Hyperlink` is now a subclass of `OpenStruct`. This allows one to set "properties" through an initial hash interface (i.e. via the `link` method) but retain a "getter method" interface and thus removing any internal instance variables.

The one gotcha I encountered was with parsing content from XML documents with Representable. While this Pull Request does work in that scenario, it doesn't allow custom attributes. It seems as if Representable's XML parsing requires properties to be set _before_ the parsing is performed instead of the document defining what the attributes should be.

While this is might be a good thing as far as Representable is concerned, I'm not sure where this implementation lies in the context of Roar. I didn't want to make any changes to Representable in order to support this Pull Request, so I left that scenario alone. At worst, it works like it did before.

I offer this Pull Request as one possible solution for a feature that I needed. Specifically, I needed data attributes and there is just no way to get that to work with the current Hyperlink implementation. This change worked for me, but if it isn't good enough for Roar, then hopefully it will open up a discussion as to how best to implement this feature.
