### PR TITLE
Fixed problem with parsing of JSON:HAL when properties are omitted

### DIFF
--- a/lib/roar/representer/json/hal.rb
+++ b/lib/roar/representer/json/hal.rb
@@ -42,6 +42,8 @@ module Roar::Representer
         
         def uncompile_fragment(bin, doc)
           return super unless bin.definition.options[:embedded]
+
+          return if doc && doc["_embedded"] && !doc["_embedded"].has_key?(bin.definition.name)
           super(bin, doc["_embedded"] || {})
         end
       end

--- a/test/hal_json_test.rb
+++ b/test/hal_json_test.rb
@@ -72,5 +72,22 @@ class HalJsonTest < MiniTest::Spec
       assert_equal [], @order.items
       assert_equal [], @order.links
     end
+
+    it "doesn't require single_item to be present" do
+      @order_rep = Module.new do
+        include Roar::Representer::JSON::HAL
+        property :id
+        property :single_item, :class => Item, :extend => Bla, :embedded => true
+        collection :items, :class => Item, :extend => Bla, :embedded => true
+        link :self do
+          "http://orders/#{id}"
+        end
+      end
+
+      @order = Order.new(:items => [Item.new(:value => "Beer")], :id => 1).extend(@order_rep)
+      @order.from_json("{\"id\":2,\"_embedded\":{\"items\":[{\"value\":\"Coffee\",\"_links\":{\"self\":{\"href\":\"http://items/Coffee\"}}}]},\"_links\":{\"self\":{\"href\":\"http://orders/2\"}}}")
+      assert_equal 2, @order.id
+      assert_equal nil, @order.single_item
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ end
 
 class Order
   include AttributesContructor
-  attr_accessor :id, :items
+  attr_accessor :id, :items, :single_item
 end
 
 require "test_xml/mini_test"


### PR DESCRIPTION
It is possible to create embedded properties with a defined class, which
is used for representation and parsing. However, when an embedded, class
configured property is omitted in the input JSON:HAL, an error (
undefined method '[]' for nil:NilClass ) is generated.

This commit provides a spec reproducing this problem and a simple fix
that checks if the property is actually in the provided document and
returns nil if it is not present.
