### PR TITLE
representer post (and put/patch) methods doesn't work because of missing body parameter.

### DIFF
--- a/lib/roar/representer/transport/net_http.rb
+++ b/lib/roar/representer/transport/net_http.rb
@@ -13,15 +13,15 @@ module Roar
         end
         
         def post_uri(uri, body, as)
-          do_request(Net::HTTP::Post, uri, as)
+          do_request(Net::HTTP::Post, uri, as, body)
         end
         
         def put_uri(uri, body, as)
-          do_request(Net::HTTP::Put, uri, as)
+          do_request(Net::HTTP::Put, uri, as, body)
         end
         
         def patch_uri(uri, body, as)
-          do_request(Net::HTTP::Patch, uri, as)
+          do_request(Net::HTTP::Patch, uri, as, body)
         end
         
         def delete_uri(uri, as)


### PR DESCRIPTION
fix missing body parameter for post put and patch in transport/net_http. Same fix may be needed for transport/faraday.
