### PR TITLE
make format argument of HttpVerbs methods optional

### DIFF
--- a/lib/roar/representer/feature/http_verbs.rb
+++ b/lib/roar/representer/feature/http_verbs.rb
@@ -32,37 +32,48 @@ module Roar
         
         # Serializes the object, POSTs it to +url+ with +format+, deserializes the returned document
         # and updates properties accordingly.
-        def post(url, format)
+        def post(url, format = nil)
+          format ||= format_from_url(url)
           response = http.post_uri(url, serialize, format)
           handle_response(response)
         end
         
         # GETs +url+ with +format+, deserializes the returned document and updates properties accordingly.
-        def get(url, format)
+        def get(url, format = nil)
+          format ||= format_from_url(url)
           response = http.get_uri(url, format)
           handle_response(response)
         end
         
         # Serializes the object, PUTs it to +url+ with +format+, deserializes the returned document
         # and updates properties accordingly.
-        def put(url, format)
+        def put(url, format = nil)
+          format ||= format_from_url(url)
           response = http.put_uri(url, serialize, format)
           handle_response(response)
           self
         end
         
-        def patch(url, format)
+        def patch(url, format = nil)
+          format ||= format_from_url(url)
           response = http.patch_uri(url, serialize, format)
           handle_response(response)
           self
         end
 
-        def delete(url, format)
+        def delete(url, format = nil)
+          format ||= format_from_url(url)
           http.delete_uri(url, format)
           self
         end
 
       private
+        def format_from_url url
+          extension = File.extname(url)[1..-1]
+          raise ArgumentError.new("Format can not read from Url '#{url}', the Url need's an extension or the format must set manually!") if extension.nil? || extension.empty?
+          "application/#{extension}"
+        end
+
         def handle_response(response)
           document = response.body
           deserialize(document)

--- a/test/fake_server.rb
+++ b/test/fake_server.rb
@@ -76,6 +76,10 @@ class FakeServer < Sinatra::Base
     {:name => "Slayer", :label => "Canadian Maple"}.to_json
   end
 
+  get "/bands/fake.json" do
+    {:name => "Fake", :label => request.env["CONTENT_TYPE"]}.to_json
+  end
+
   delete '/banks/metallica' do
     status 204
   end

--- a/test/http_verbs_feature_test.rb
+++ b/test/http_verbs_feature_test.rb
@@ -104,6 +104,20 @@ class HttpVerbsTest < MiniTest::Spec
       end
     end
 
+    describe "#format_from_url" do
+      it "returns the format of the extention" do
+        @band.get "http://roar.example.com/bands/fake.json"
+        assert_equal 'Fake', @band.name
+        assert_equal 'application/json', @band.label
+      end
+
+      it "raise an error" do
+        assert_raises(ArgumentError) do
+          @band.get "http://roar.example.com/bands/fake"
+        end
+      end
+    end
+
     # HEAD, OPTIONs?
 
   end


### PR DESCRIPTION
make format argument of HttpVerbs methods optional and detect them by the extension if the Url has one
