### PR TITLE
Support for dynamic link attributes

### DIFF
--- a/lib/roar/representer/feature/hypermedia.rb
+++ b/lib/roar/representer/feature/hypermedia.rb
@@ -20,6 +20,12 @@ module Roar
       #       "http://orders/#{id}"
       #     end
       #
+      # If you need dynamic attributes, the block can return a hash.
+      #
+      #     link :preview do
+      #       {:href => image.url, :title => image.name}
+      #     end
+      #
       # Sometimes you need values from outside when the representation links are rendered. Just pass them
       # to the render method, they will be available as block parameters.
       #
@@ -53,8 +59,9 @@ module Roar
           
           links_def.rel2block.each do |config|  # config is [{..}, block]
             options = config.first
-            options[:href] = run_link_block(config.last, *args) or next
-            
+            href = run_link_block(config.last, *args) or next
+            options.merge! href.is_a?(Hash) ? href : {:href => href}
+
             links.update_link(Feature::Hypermedia::Hyperlink.new(options))
           end
         end

--- a/test/hypermedia_feature_test.rb
+++ b/test/hypermedia_feature_test.rb
@@ -41,6 +41,16 @@ class HypermediaTest
 
         assert_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"http://self/1\"}]}", Object.new.extend(@mod).to_json(:id => 1)
       end
+
+      it "supports returning hash" do
+        @mod.class_eval do
+          link :self do
+            {:href => "http://self", :type => "image/jpg"}
+          end
+        end
+
+        assert_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"http://self\",\"type\":\"image/jpg\"}]}", Object.new.extend(@mod).to_json
+      end
     end
 
 


### PR DESCRIPTION
This adds support for dynamically setting other link attributes by returning a hash.

``` ruby
link :source do
  {:href => url, :type => content_type, :title => title}
end
```
