### PR TITLE
Update JSON::HAL to work with representable 1.2.8

### DIFF
--- a/lib/roar/representer/json/hal.rb
+++ b/lib/roar/representer/json/hal.rb
@@ -36,12 +36,12 @@ module Roar::Representer
       module Resources
         # Write the property to the +_embedded+ hash when it's a resource.
         def compile_fragment(bin, doc)
-          return super unless bin.definition.options[:embedded]
+          return super unless bin.options[:embedded]
           super(bin, doc[:_embedded] ||= {})
         end
         
         def uncompile_fragment(bin, doc)
-          return super unless bin.definition.options[:embedded]
+          return super unless bin.options[:embedded]
           super(bin, doc["_embedded"] || {})
         end
       end


### PR DESCRIPTION
This patch simply removes the Binding#definition call in the HAL module, as the methods are automatically forwarded.

Before the change a fresh `bundle && rake` was giving me the following error:

```
Binding#definition is no longer supported as all Definition methods are now delegated automatically.
```

See [this gist](https://gist.github.com/3997065) for the full output.

But after updating the HAL module everything is green, and my app that uses roar-rails works again :thumbsup: 
