### PR TITLE
Chaining composition should not clear the previously defined links

### DIFF
--- a/test/hypermedia_test.rb
+++ b/test/hypermedia_test.rb
@@ -54,6 +54,23 @@ class HypermediaTest < MiniTest::Spec
             Song.new(:entity => Song.new).extend(rpr).to_json(:id => 1).must_equal "{\"entity\":{\"links\":[{\"rel\":\"self\",\"href\":\"//self/1\"}]},\"links\":[{\"rel\":\"self\",\"href\":\"//self/1\"}]}"
           end
         end
+
+        describe "in chained compositions" do
+          representer_for do
+            link(:self) { |opts| "//self" }
+          end
+
+          it "retains links" do
+            canonical = Module.new do
+              include Roar::Representer::JSON
+              include Roar::Representer::Feature::Hypermedia
+
+              link(:canonical) { "//self/canonical" }
+            end
+
+            subject.extend(canonical).to_json.must_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"//self\"},{\"rel\":\"canonical\",\"href\":\"//self/canonical\"}]}"
+          end
+        end
       end
 
       describe "returning option hash from block" do


### PR DESCRIPTION
Added a failing test to show desired behavior.

I think this is caused by the `include Roar::Representer::JSON` or `include Roar::Representer::Feature::Hypermedia`, as they might be re-defining the current state instead of reusing it. This is a wild guess; I haven't looked at the code yet.

My use case is re-using existing representers whenever possible. For example:

``` ruby
module SomeCollection
  include Roar::Representer::JSON::HAL
  include Pagination
  include Curie
  [...]
end
```

Thoughts?
