### PR TITLE
HAL::Links module shouldn't prepend an underscore to links

### DIFF
--- a/lib/roar/representer/json/hal.rb
+++ b/lib/roar/representer/json/hal.rb
@@ -160,7 +160,7 @@ module Roar::Representer
           def links_definition_options
             super.tap { |options|
               options[0] = :links
-              options[1] = {:class => Feature::Hypermedia::LinkCollection, :extend => LinkCollectionRepresenter, :from => :_links} 
+              options[1] = {:class => Feature::Hypermedia::LinkCollection, :extend => LinkCollectionRepresenter}
             }
 
           end

--- a/test/hal_links_test.rb
+++ b/test/hal_links_test.rb
@@ -1,0 +1,26 @@
+require 'ostruct'
+require 'test_helper'
+require 'roar/representer/json/hal'
+
+
+class HalLinkTest < MiniTest::Spec
+  let(:rpr) do
+    Module.new do
+      include Roar::Representer::JSON
+      include Roar::Representer::JSON::HAL::Links
+      link :self do
+        "me"
+      end
+    end
+  end
+
+  subject { Object.new.extend(rpr) }
+
+  describe "#prepare_links!" do
+    it "should use 'links' key" do
+      assert_equal subject.to_json, "{\"links\":{\"self\":{\"href\":\"me\"}}}"
+      puts subject.to_json
+    end
+  end
+end
+


### PR DESCRIPTION
According to the [docs](https://github.com/apotonick/roar/blob/master/lib/roar/representer/json/hal.rb#L84) the links key should not have an underscore. That should be added when the HAL module in mixed in and overrides the links_definition_options.

I prefer the hal-like syntax for the links key, but w/o the underscore.
