### PR TITLE
Make the attribute accessor code in Client a bit shorter

### DIFF
--- a/lib/roar/representer/feature/client.rb
+++ b/lib/roar/representer/feature/client.rb
@@ -8,21 +8,12 @@ module Roar
         include HttpVerbs
 
         def self.extended(base)
-          base.instance_eval do
-            representable_attrs.each do |attr|
+          target = base.is_a?(Module) ? base : base.singleton_class
+
+          target.class_eval do
+            base.send(:representable_attrs).each do |attr|
               next unless attr.instance_of? Representable::Definition # ignore hyperlinks etc for now.
-              name = attr.name
-
-              # TODO: could anyone please make this better?
-              instance_eval %Q{
-                def #{name}=(v)
-                  @#{name} = v
-                end
-
-                def #{name}
-                  @#{name}
-                end
-              }
+              attr_accessor attr.name
             end
           end
         end


### PR DESCRIPTION
While I was reading the ROAR source I noticed the following code commented with a request for someone to clean it up a bit:

https://github.com/apotonick/roar/blob/master/lib/roar/representer/feature/client.rb#L16-L25

``` ruby
# TODO: could anyone please make this better?
instance_eval %Q{
  def #{name}=(v)
    @#{name} = v
  end

  def #{name}
    @#{name}
  end
}
```

So I had a go…

This is only a quick hack. The tests don't care whether I evaluate it into the host object's class or singleton class, and I didn't stop to think about any other uncaught bugs this might introduce. But at least it's removed the nested string eval.
