### PR TITLE
Link options (context?) should be re-evaluated during serialization

### DIFF
--- a/test/hypermedia_test.rb
+++ b/test/hypermedia_test.rb
@@ -107,10 +107,20 @@ class HypermediaTest < MiniTest::Spec
       describe "returning option hash from block" do
         representer_for do
           link(:self) do {:href => "//self", :type => "image/jpg"} end
+          link(:other) do |params|
+            hash = { :href => "//other" }
+            hash.merge!(:type => 'image/jpg') if params[:type]
+            hash
+          end
         end
 
         it "is rendered as link attributes" do
-          subject.to_json.must_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"//self\",\"type\":\"image/jpg\"}]}"
+          subject.to_json.must_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"//self\",\"type\":\"image/jpg\"},{\"rel\":\"other\",\"href\":\"//other\"}]}"
+        end
+
+        it "is rendered according to context" do
+          subject.to_json(type: true).must_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"//self\",\"type\":\"image/jpg\"},{\"rel\":\"other\",\"href\":\"//other\",\"type\":\"image/jpg\"}]}"
+          subject.to_json.must_equal "{\"links\":[{\"rel\":\"self\",\"href\":\"//self\",\"type\":\"image/jpg\"},{\"rel\":\"other\",\"href\":\"//other\"}]}"
         end
       end
 


### PR DESCRIPTION
Yo Nick,

I ran across a behavior which I believe is not intended. Basically, we're conditionally adding properties to links depending on the user's permissions. However, once the condition is true for link "X", **every** user will have the property showing up for that link, regardless of the options passed in to `to_json`.

I've attached a PR that reproduces the gist of it. I have to run now, but I'll try to dig deeper during the weekend. Any ideas?

Cheers!
