### PR TITLE
let clients parse lonely collections

### DIFF
--- a/lib/roar/json/collection.rb
+++ b/lib/roar/json/collection.rb
@@ -1,3 +1,11 @@
-require "representable/json/collection"
+require 'roar/json'
 
-Roar::JSON::Collection = Representable::JSON::Collection
+module Roar::JSON
+  module Collection
+    include Roar::JSON
+
+    def self.included(base)
+      base.send :include, Representable::Hash::Collection
+    end
+  end
+end

--- a/test/integration/server.rb
+++ b/test/integration/server.rb
@@ -55,6 +55,12 @@ post "/bands" do
   status 201
 end
 
+get '/bands' do
+  [OpenStruct.new(:name => "Slayer", :label => "Canadian Maple"),
+   OpenStruct.new(:name => "Nirvana", :label => "Sub Pop")]
+    .extend(Integration::BandRepresenter.for_collection).to_json
+end
+
 put "/bands/strungout" do
   # DISCUSS: as long as we don't agree on what to return in PUT/PATCH, let's return an updated document.
   body consume_band.to_json

--- a/test/json_collection_test.rb
+++ b/test/json_collection_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+require 'roar/json/collection'
+require 'roar/client'
+
+class JsonCollectionTest < MiniTest::Spec
+  class Band < OpenStruct; end
+
+  module BandRepresenter
+    include Roar::JSON
+
+    property :name
+    property :label
+  end
+
+  module BandsRepresenter
+    include Roar::JSON::Collection
+
+    items extend: BandRepresenter, class: Band
+  end
+  
+  class Bands < Array
+    include Roar::JSON::Collection
+    include BandsRepresenter
+    include Roar::Client
+  end
+
+  let(:bands) { Bands.new }
+
+  # "[{\"name\":\"Slayer\",\"label\":\"Canadian Maple\"},{\"name\":\"Nirvana\",\"label\":\"Sub Pop\"}])"
+  it 'fetches lonely collection of existing bands' do
+    bands.get(uri: 'http://localhost:4567/bands', as: 'application/json')
+    bands.size.must_equal(2)
+    bands[0].name.must_equal('Slayer')
+  end
+end

--- a/test/lonely_test.rb
+++ b/test/lonely_test.rb
@@ -4,6 +4,5 @@ require "roar/json/collection"
 require "roar/json/hash"
 
 class LonelyCollectionTest < MiniTest::Spec
-  it { Roar::JSON::Collection.must_equal Representable::JSON::Collection }
   it { Roar::JSON::Hash.must_equal Representable::JSON::Hash }
 end


### PR DESCRIPTION
As an API designer, I'm not a fan of the lonely collection pattern, but I encounter it with some regularity in legacy code.

I wrote the test using the module pattern because I sorted this out while working with decorator-based clients and I wanted to be sure both the issue and the fix were the same for both patterns. Should we have a decorator-client test as well? I could easily add one.
