### PR TITLE
Allow links to accept a string so that curie links work properly

### DIFF
--- a/lib/roar/json/hal.rb
+++ b/lib/roar/json/hal.rb
@@ -200,7 +200,7 @@ module Roar
           #      {:lang => "de", :href => "http://de.hit"}]
           #   end
           def links(options, &block)
-            options = {:rel => options} if options.is_a?(Symbol)
+            options = {:rel => options} if options.is_a?(Symbol) || options.is_a?(String)
             options[:array] = true
             link(options, &block)
           end

--- a/test/hal_json_test.rb
+++ b/test/hal_json_test.rb
@@ -149,6 +149,10 @@ class HalCurieTest < MiniTest::Spec
       "/"
     end
 
+    links "doc:link_collection" do
+      [{:name => "link_collection", :href => "/"}]
+    end
+
     curies do
       [{:name => :doc,
         :href => "//docs/{rel}",
@@ -156,5 +160,5 @@ class HalCurieTest < MiniTest::Spec
     end
   end
 
-  it { Object.new.extend(rpr).to_hash.must_equal({"_links"=>{"doc:self"=>{"href"=>"/"}, :curies=>[{"name"=>:doc, "href"=>"//docs/{rel}", "templated"=>true}]}}) }
+  it { Object.new.extend(rpr).to_hash.must_equal({"_links"=>{"doc:self"=>{"href"=>"/"}, "doc:link_collection"=>[{"name"=>"link_collection", "href"=>"/"}], :curies=>[{"name"=>:doc, "href"=>"//docs/{rel}", "templated"=>true}]}}) }
 end


### PR DESCRIPTION
The title says it all: HAL representers should also allow curie links for link collections. Unless I missed something this did not yet seem possible.
