### PR TITLE
Enable JSONAPI#to_hash meta option 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -514,23 +514,23 @@ compound do
 end
 ```
 
-### Meta Data
+### Meta information
 
-Meta data can be included into the rendered collection document in two ways. Please note that parsing the `meta` field is not implemented, yet, as I wasn't sure if people need it.
+Meta information can be included into rendered singular and collection documents in two ways.
 
-You can define meta data on your collection object and then let Roar compile it.
+You can define meta information on your collection object and then let Roar compile it.
 
 ```ruby
 module SongsRepresenter
   # ..
 
-  meta do
+  meta toplevel: true do
     property :page
     property :total
   end
 ```
 
-Your collection object has to expose those methods.
+Your collection object must expose the respective methods.
 
 ```ruby
 collection.page  #=> 1
@@ -539,10 +539,27 @@ collection.total #=> 12
 
 This will render the `{"meta": {"page": 1, "total": 12}}` hash into the JSON-API document.
 
-Another way is to provide the _complete_ meta data hash when rendering. You must not define any `meta` properties in the representer when using this approach.
+Alternatively, you can provide meta information as a hash when rendering.  Any values also defined on your object will be overriden.
 
 ```ruby
 collection.to_json("meta" => {page: params["page"], total: collection.size})
+```
+
+Both methods work for singular documents too.
+
+```ruby
+module SongsRepresenter
+  # ..
+
+  meta do
+    property :label
+    property :format
+  end
+end
+```
+
+```ruby
+song.to_json("meta" => { label: 'EMI' })
 ```
 
 If you need more functionality (and parsing), please let us know.

--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -33,11 +33,12 @@ module Roar
             # link(:self) { .. }
 
             def self.meta(options={}, &block)
-              meta_representer = Class.new(Roar::Decorator)
-              meta_representer.include(Roar::JSON)
-              meta_representer.instance_exec(&block)
-
-              representable_attrs[:meta_representer] = meta_representer
+              representable_attrs[:meta_representer] ||= begin
+                meta_representer = Class.new(Roar::Decorator)
+                meta_representer.include(Roar::JSON)
+                meta_representer
+              end
+              representable_attrs[:meta_representer].instance_exec(&block)
             end
 
             def to_hash(options={})
@@ -92,11 +93,12 @@ module Roar
         def meta(options={}, &block)
           return for_collection.meta(name, &block) if options[:toplevel]
 
-          meta_representer = Class.new(Roar::Decorator)
-          meta_representer.include(Roar::JSON)
-          meta_representer.instance_exec(&block)
-
-          representable_attrs[:meta_representer] = meta_representer
+          representable_attrs[:meta_representer] ||= begin
+            meta_representer = Class.new(Roar::Decorator)
+            meta_representer.include(Roar::JSON)
+            meta_representer
+          end
+          representable_attrs[:meta_representer].instance_exec(&block)
         end
 
         def has_one(name, options={}, &block)

--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -1,5 +1,6 @@
 require 'roar/json'
 require 'roar/decorator'
+require 'set'
 
 module Roar
   module JSON

--- a/lib/roar/json/json_api.rb
+++ b/lib/roar/json/json_api.rb
@@ -63,10 +63,10 @@ module Roar
             private
 
             def render_meta(options)
-              return options["meta"] if options["meta"]
-              return {} unless representer = representable_attrs[:meta_representer]
-
-              representer.new(represented).to_hash
+              representer = representable_attrs[:meta_representer]
+              meta        = representer ? representer.new(represented).to_hash : {}
+              meta.merge!(options['meta']) if options['meta']
+              meta
             end
           end)
         end
@@ -251,10 +251,10 @@ module Roar
         end
 
         def render_meta(options)
-          return options["meta"] if options["meta"]
-          return {} unless representer = representable_attrs[:meta_representer]
-
-          representer.new(represented).to_hash
+          representer = representable_attrs[:meta_representer]
+          meta        = representer ? representer.new(represented).to_hash : {}
+          meta.merge!(options['meta']) if options['meta']
+          meta
         end
 
         def render_relationships(res)

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -57,6 +57,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                :links=>{"self"=>"http://comments/comment:4"}}},
            :links=>{"self"=>"http://Article/3"}}],
        :links=>{"self"=>"//articles"},
+       :meta=>{"count" => 3},
        :included=>
         [{:type=>"authors", :id=>"2", :links=>{"self"=>"http://authors/2"}},
          {:type=>"editors",
@@ -131,6 +132,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                :links=>{"self"=>"http://comments/comment:4"}}},
            :links=>{"self"=>"http://Article/3"}}],
        :links=>{"self"=>"//articles"},
+       :meta=>{"count" => 3}
       }
     )
   end
@@ -152,6 +154,9 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
         "links" => {
           "self" => "//articles"
         },
+        "meta" => {
+          "count" => 0
+        }
       }
     }
 

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -137,14 +137,15 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     )
   end
 
-  it 'renders meta information if meta option supplied' do
+  it 'renders additional meta information if meta option supplied' do
     hash = decorator.to_hash('meta' => { page: 2, total: 9 })
-    hash[:meta].must_equal(page: 2, total: 9)
+    hash[:meta].must_equal("count" => 3, page: 2, total: 9)
   end
 
-  it 'does not render meta information if meta option is empty' do
+  it 'does not render additional meta information if meta option is empty' do
     hash = decorator.to_hash('meta' => {})
-    hash[:meta].must_be_nil
+    hash[:meta][:page].must_be_nil
+    hash[:meta][:total].must_be_nil
   end
 
   describe "Fetching Resources (empty collection)" do

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -135,6 +135,16 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     )
   end
 
+  it 'renders meta information if meta option supplied' do
+    hash = decorator.to_hash('meta' => { page: 2, total: 9 })
+    hash[:meta].must_equal(page: 2, total: 9)
+  end
+
+  it 'does not render meta information if meta option is empty' do
+    hash = decorator.to_hash('meta' => {})
+    hash[:meta].must_be_nil
+  end
+
   describe "Fetching Resources (empty collection)" do
     let(:document) {
       {

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -64,7 +64,8 @@ class JsonapiRenderTest < MiniTest::Spec
             :attributes=>{"body"=>"Red Stripe Skank"},
             :links=>{"self"=>"http://comments/comment:2"}
             },
-          ]
+          ],
+        :meta=>{"reviewer"=>"Christian Bernstein"}
         })
 
   end
@@ -97,7 +98,8 @@ class JsonapiRenderTest < MiniTest::Spec
                   ], # FIXME.
                  :links=>{"self"=>"http://comments/comment:2"}}}, # FIXME: this only works when a relationship is present.
              :links=>{"self"=>"http://Article/1"}
-        }
+        },
+        :meta=>{"reviewer"=>"Christian Bernstein"}
       }
     )
   end

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -65,7 +65,7 @@ class JsonapiRenderTest < MiniTest::Spec
             :links=>{"self"=>"http://comments/comment:2"}
             },
           ],
-        :meta=>{"reviewer"=>"Christian Bernstein"}
+        :meta=>{"reviewer"=>"Christian Bernstein", "reviewer_initials"=>"C.B."}
         })
 
   end
@@ -99,7 +99,7 @@ class JsonapiRenderTest < MiniTest::Spec
                  :links=>{"self"=>"http://comments/comment:2"}}}, # FIXME: this only works when a relationship is present.
              :links=>{"self"=>"http://Article/1"}
         },
-        :meta=>{"reviewer"=>"Christian Bernstein"}
+        :meta=>{"reviewer"=>"Christian Bernstein", "reviewer_initials"=>"C.B."}
       }
     )
   end

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -65,7 +65,7 @@ class JsonapiRenderTest < MiniTest::Spec
             :links=>{"self"=>"http://comments/comment:2"}
             },
           ],
-        :meta=>{"reviewer"=>"Christian Bernstein", "reviewer_initials"=>"C.B."}
+        :meta=>{"reviewers"=>["Christian Bernstein"], "reviewer_initials"=>"C.B."}
         })
 
   end
@@ -99,19 +99,25 @@ class JsonapiRenderTest < MiniTest::Spec
                  :links=>{"self"=>"http://comments/comment:2"}}}, # FIXME: this only works when a relationship is present.
              :links=>{"self"=>"http://Article/1"}
         },
-        :meta=>{"reviewer"=>"Christian Bernstein", "reviewer_initials"=>"C.B."}
+        :meta=>{"reviewers"=>["Christian Bernstein"], "reviewer_initials"=>"C.B."}
       }
     )
   end
 
-  it 'renders meta information if meta option supplied' do
-    hash = decorator.to_hash('meta' => { 'copyright' => 'Nick Sutterer' })
-    hash[:meta].must_equal('copyright' => 'Nick Sutterer')
+  it 'renders additional meta information if meta option supplied' do
+    hash = decorator.to_hash('meta' => {
+      'copyright' => 'Nick Sutterer', 'reviewers' => []
+    })
+    hash[:meta]['copyright'].must_equal('Nick Sutterer')
+    hash[:meta]['reviewers'].must_equal([])
+    hash[:meta]['reviewer_initials'].must_equal('C.B.')
   end
 
-  it 'does not render meta information if meta option is empty' do
+  it 'does not render additonal meta information if meta option is empty' do
     hash = decorator.to_hash('meta' => {})
-    hash[:meta].must_be_nil
+    hash[:meta]['copyright'].must_be_nil
+    hash[:meta]['reviewers'].must_equal(['Christian Bernstein'])
+    hash[:meta]['reviewer_initials'].must_equal('C.B.')
   end
 
   describe "Single Resource Object" do

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -102,6 +102,16 @@ class JsonapiRenderTest < MiniTest::Spec
     )
   end
 
+  it 'renders meta information if meta option supplied' do
+    hash = decorator.to_hash('meta' => { 'copyright' => 'Nick Sutterer' })
+    hash[:meta].must_equal('copyright' => 'Nick Sutterer')
+  end
+
+  it 'does not render meta information if meta option is empty' do
+    hash = decorator.to_hash('meta' => {})
+    hash[:meta].must_be_nil
+  end
+
   describe "Single Resource Object" do
     class DocumentSingleResourceObjectDecorator < Roar::Decorator
       include Roar::JSON::JSONAPI

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -6,8 +6,8 @@ end
 AuthorNine = Author.new(9, "9@nine.to")
 
 Article = Struct.new(:id, :title, :author, :editor, :comments) do
-  def reviewer
-    'Christian Bernstein'
+  def reviewers
+    ['Christian Bernstein']
   end
 end
 
@@ -35,12 +35,14 @@ class ArticleDecorator < Roar::Decorator
   property :title
 
   meta do
-    property :reviewer
+    collection :reviewers
   end
 
   meta do
     property :reviewer_initials, getter: ->(_) {
-      reviewer.split.map { |name| "#{name[0]}." }.join
+      reviewers.map {|reviewer|
+        reviewer.split.map { |name| "#{name[0]}." }.join
+      }.join(', ')
     }
   end
 

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -5,7 +5,11 @@ Author = Struct.new(:id, :email, :name) do
 end
 AuthorNine = Author.new(9, "9@nine.to")
 
-Article = Struct.new(:id, :title, :author, :editor, :comments)
+Article = Struct.new(:id, :title, :author, :editor, :comments) do
+  def reviewer
+    'Christian Bernstein'
+  end
+end
 
 Comment = Struct.new(:id, :body) do
   def self.find_by(options)
@@ -22,10 +26,17 @@ class ArticleDecorator < Roar::Decorator
     "//articles"
   end
 
+  meta toplevel: true do
+    property :count
+  end
+
   # attributes: {}
   property :id
   property :title
 
+  meta do
+    property :reviewer
+  end
 
   # resource object links
   link(:self) { "http://#{represented.class}/#{represented.id}" }

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -38,6 +38,12 @@ class ArticleDecorator < Roar::Decorator
     property :reviewer
   end
 
+  meta do
+    property :reviewer_initials, getter: ->(_) {
+      reviewer.split.map { |name| "#{name[0]}." }.join
+    }
+  end
+
   # resource object links
   link(:self) { "http://#{represented.class}/#{represented.id}" }
 


### PR DESCRIPTION
N.B. This removes incomplete implementation of `meta` field.

Fixes #196 