### PR TITLE
Travis: use jruby-9.1.13.0; build green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ matrix:
     - rvm: 2.3.1
     - rvm: 2.4.0
     - rvm: jruby-9.1.13.0
+      env:
+        - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
+language: ruby
 sudo: false
-rvm:
-  - 1.9.3
-  - 2.1
-  - 2.2.6
-  - 2.3.1
-  - 2.4.0
-  - jruby-9.1.13.0
-  - ruby-head
-gemfile:
-  - Gemfile
-  # - gemfiles/Gemfile.representable-2.4
 before_install:
   - gem install bundler
 matrix:
   allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+    - rvm: 2.1
+    - rvm: 2.2.6
+    - rvm: 2.3.1
+    - rvm: 2.4.0
+    - rvm: jruby-9.1.13.0
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.2.6
   - 2.3.1
   - 2.4.0
-  - jruby-9.1.6.0
+  - jruby-9.1.13.0
   - ruby-head
 gemfile:
   - Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,10 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-# Specify your gem's dependencies in roar.gemspec
+ruby RUBY_VERSION
+
 gemspec
-
-install_if -> { RUBY_VERSION > '2.2.2' } do
-  gem 'sinatra',          '~> 2.0'
-  gem 'sinatra-contrib',  '~> 2.0'
-end
 
 gem 'nokogiri', '~> 1.6.8'
 
-# gem "representable", path: "../representable"
-# gem "representable", github: "apotonick/representable"
-# gem "declarative", path: "../declarative"
 gem "minitest-line"
 gem "pry"

--- a/README.markdown
+++ b/README.markdown
@@ -67,6 +67,12 @@ The roar gem runs with all Ruby versions >= 1.9.3.
 gem 'roar'
 ```
 
+To use roar with Ruby versions < 2.2.0, add a version pin to your Gemfile:
+
+```ruby
+gem 'sinatra', '~> 1.4'
+```
+
 ### Dependencies
 
 Roar does not bundle dependencies for JSON and XML.

--- a/roar.gemspec
+++ b/roar.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", ">= 0.10.1"
   s.add_development_dependency "test_xml", "0.1.6"
   s.add_development_dependency 'minitest', '>= 5.10'
-  s.add_development_dependency "sinatra", '>= 2.0.0'
-  s.add_development_dependency "sinatra-contrib", '>= 2.0.0'
+  s.add_development_dependency "sinatra"
+  s.add_development_dependency "sinatra-contrib"
   s.add_development_dependency "virtus", ">= 1.0.0"
   s.add_development_dependency "faraday"
   s.add_development_dependency "multi_json"


### PR DESCRIPTION
This PR:

- updates the CI matrix to use **[latest JRuby](http://jruby.org/2017/09/06/jruby-9-1-13-0.html)**. 
- **keeps the 1.9.3 support**
- documents usage with Ruby versions < 2.2.0 in the README
- reorganizes the CI matrix to enable build-specific `env` variables
- on JRuby build: configures `JRUBY_OPTS` to avoid warnings