### PR TITLE
CI: Use latest JRuby 9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - rvm: 2.2.6
     - rvm: 2.3.1
     - rvm: 2.4.0
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.2.8.0
       env:
         - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false -J-Xmx1536m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)