### PR TITLE
loosen version requirement on representable

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+# 1.1.1
+
+* Require [representable](https://github.com/trailblazer/representable/) 3.x.x
+
 # 1.1.0
 
 * Require Representable 3.0.x

--- a/lib/roar/version.rb
+++ b/lib/roar/version.rb
@@ -1,3 +1,3 @@
 module Roar
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/roar.gemspec
+++ b/roar.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency "representable", "~> 3.0.0"
+  s.add_runtime_dependency "representable", ">= 3.0.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "test_xml", "0.1.6"

--- a/roar.gemspec
+++ b/roar.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency "representable", ">= 3.0.0"
+  s.add_runtime_dependency "representable", "~> 3.1.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "test_xml", "0.1.6"

--- a/test/integration/faraday_http_transport_test.rb
+++ b/test/integration/faraday_http_transport_test.rb
@@ -61,7 +61,7 @@ class FaradayHttpTransportTest < MiniTest::Spec
 
     describe 'server errors (500 Internal Server Error)' do
       it '#get_uri raises a ClientError' do
-        assert_raises(Faraday::ClientError) do
+        assert_raises(Faraday::ServerError) do
           @transport.get_uri(uri: 'http://localhost:4567/deliberate-error', as: as).body
         end
       end

--- a/test/integration/faraday_http_transport_test.rb
+++ b/test/integration/faraday_http_transport_test.rb
@@ -35,25 +35,25 @@ class FaradayHttpTransportTest < MiniTest::Spec
       let(:not_found_url) { 'http://localhost:4567/missing-resource' }
 
       it '#get_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.get_uri(uri: not_found_url, as: as).body
         end
       end
 
       it '#post_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.post_uri(uri: not_found_url, body: body, as: as).body
         end
       end
 
       it '#post_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.post_uri(uri: not_found_url, body: body, as: as).body
         end
       end
 
       it '#delete_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.delete_uri(uri: not_found_url, body: body, as: as).body
         end
       end
@@ -61,7 +61,7 @@ class FaradayHttpTransportTest < MiniTest::Spec
 
     describe 'server errors (500 Internal Server Error)' do
       it '#get_uri raises a ClientError' do
-        assert_raises(Faraday::Error::ClientError) do
+        assert_raises(Faraday::ClientError) do
           @transport.get_uri(uri: 'http://localhost:4567/deliberate-error', as: as).body
         end
       end

--- a/test/integration/http_verbs_test.rb
+++ b/test/integration/http_verbs_test.rb
@@ -54,7 +54,7 @@ class HttpVerbsTest < MiniTest::Spec
       describe 'a non-existent resource' do
         it 'handles HTTP errors and raises a ResourceNotFound error with FaradayHttpTransport' do
           @band.transport_engine = Roar::Transport::Faraday
-          assert_raises(::Faraday::Error::ResourceNotFound) do
+          assert_raises(::Faraday::ResourceNotFound) do
             @band.get(uri: 'http://localhost:4567/bands/anthrax', as: "application/json")
           end
         end


### PR DESCRIPTION
with the previous restriction, upgrading to representable 3.1.0 caused roar to be downgraded to 0.12.7.

There was no other combination of compatible versions.

```
~ # cat Gemfile
# frozen_string_literal: true

source 'https://rubygems.org'

gem 'representable', '~>3.1.0'
gem 'roar', '~>1.1.0'

~ # bundle install 
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Bundler could not find compatible versions for gem "representable":
  In Gemfile:
    representable (~> 3.1.0)

    roar (~> 1.1.0) was resolved to 1.1.0, which depends on
      representable (~> 3.0.0)
```