### PR TITLE
Allow to use Representable 3.1+

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,8 @@
+# Next
+
+* Allow Representable `>= 3.1`
+* Replace `Virtus` with `Dry-Types`
+
 # 1.1.1
 
 * Allow Representable 3.x.

--- a/README.markdown
+++ b/README.markdown
@@ -296,7 +296,7 @@ We're currently [working on](https://github.com/trailblazer/roar/issues/85) bett
 
 ## Coercion
 
-Roar provides coercion with the [virtus](https://github.com/solnic/virtus) gem.
+Roar provides coercion with the [dry-types](https://dry-rb.org/gems/dry-types/) gem.
 
 ```ruby
 require 'roar/coercion'
@@ -307,11 +307,11 @@ class SongRepresenter < Roar::Decorator
   include Roar::Coercion
 
   property :title
-  property :released_at, type: DateTime
+  property :released_at, type: Types::DateTime
 end
 ```
 
-The `:type` option allows to set a virtus-compatible type.
+The `:type` option allows to set a dry-types-compatible type.
 
 ```ruby
 song = Song.new

--- a/lib/roar/coercion.rb
+++ b/lib/roar/coercion.rb
@@ -1,8 +1,10 @@
-gem 'virtus'
-require 'virtus'
-require 'representable/coercion'
+gem "dry-types", ">= 1.0.0"
+require "dry-types"
+require "representable/coercion"
 
 module Roar
+  Types = Representable::Coercion::Types
+
   # Use the +:type+ option to specify the conversion type.
   # class ImmigrantSong
   #   include Roar::JSON

--- a/roar.gemspec
+++ b/roar.gemspec
@@ -19,14 +19,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency "representable", "~> 3.0"
+  s.add_runtime_dependency "representable", "~> 3.1"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "test_xml", "0.1.6"
   s.add_development_dependency 'minitest', '>= 5.10'
   s.add_development_dependency "sinatra"
   s.add_development_dependency "sinatra-contrib"
-  s.add_development_dependency "virtus", ">= 1.0.0"
+  s.add_development_dependency "webrick"
   s.add_development_dependency "faraday"
   s.add_development_dependency "multi_json"
+  s.add_development_dependency "dry-types", ">= 1.0.0"
 end

--- a/test/coercion_feature_test.rb
+++ b/test/coercion_feature_test.rb
@@ -8,7 +8,7 @@ class CoercionFeatureTest < MiniTest::Spec
       include Roar::JSON
       include Roar::Coercion
 
-      property :composed_at, :type => DateTime, :default => "May 12th, 2012"
+      property :composed_at, type: Types::JSON::DateTime, default: "May 12th, 2012"
     end
 
     class ImmigrantSong

--- a/test/integration/faraday_http_transport_test.rb
+++ b/test/integration/faraday_http_transport_test.rb
@@ -35,25 +35,25 @@ class FaradayHttpTransportTest < MiniTest::Spec
       let(:not_found_url) { 'http://localhost:4567/missing-resource' }
 
       it '#get_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.get_uri(uri: not_found_url, as: as).body
         end
       end
 
       it '#post_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.post_uri(uri: not_found_url, body: body, as: as).body
         end
       end
 
       it '#post_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.post_uri(uri: not_found_url, body: body, as: as).body
         end
       end
 
       it '#delete_uri raises a ResourceNotFound error' do
-        assert_raises(Faraday::Error::ResourceNotFound) do
+        assert_raises(Faraday::ResourceNotFound) do
           @transport.delete_uri(uri: not_found_url, body: body, as: as).body
         end
       end
@@ -61,7 +61,7 @@ class FaradayHttpTransportTest < MiniTest::Spec
 
     describe 'server errors (500 Internal Server Error)' do
       it '#get_uri raises a ClientError' do
-        assert_raises(Faraday::Error::ClientError) do
+        assert_raises(Faraday::ServerError) do
           @transport.get_uri(uri: 'http://localhost:4567/deliberate-error', as: as).body
         end
       end

--- a/test/integration/http_verbs_test.rb
+++ b/test/integration/http_verbs_test.rb
@@ -54,7 +54,7 @@ class HttpVerbsTest < MiniTest::Spec
       describe 'a non-existent resource' do
         it 'handles HTTP errors and raises a ResourceNotFound error with FaradayHttpTransport' do
           @band.transport_engine = Roar::Transport::Faraday
-          assert_raises(::Faraday::Error::ResourceNotFound) do
+          assert_raises(::Faraday::ResourceNotFound) do
             @band.get(uri: 'http://localhost:4567/bands/anthrax', as: "application/json")
           end
         end

--- a/test/integration/ssl_server.rb
+++ b/test/integration/ssl_server.rb
@@ -58,4 +58,4 @@ class SslServer < Sinatra::Base
 end
 server = ::Rack::Handler::WEBrick
 
-server.run(SslServer, webrick_options)
+server.run(SslServer, **webrick_options)


### PR DESCRIPTION
Replace Virtus with Dry-Types to make Roar compatible with Representable 3.1

Resolves #217, resolves #222